### PR TITLE
Fixes link to mr_uplift_one_response_example.ipynb

### DIFF
--- a/examples/mr_uplift_multiple_response_example.ipynb
+++ b/examples/mr_uplift_multiple_response_example.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "## Introduction \n",
     "\n",
-    "This notebook will go over optimization of multiple response variables using the MRUplift Framework. Readers are encouraged to read the [example on single responses](https://github.com/Ibotta/ibotta_uplift/blob/master/examples/ibotta_uplift_multiple_response_example.ipynb) if they'd like a general introduction to uplift models. This will go over:\n",
+    "This notebook will go over optimization of multiple response variables using the MRUplift Framework. Readers are encouraged to read the [example on single responses](https://github.com/Ibotta/ibotta_uplift/blob/master/examples/mr_uplift_one_response_example.ipynb) if they'd like a general introduction to uplift models. This will go over:\n",
     "\n",
     "1. Hypothetical Problem and The Data Generating Process\n",
     "\n",


### PR DESCRIPTION
Originally the link with name "example on single responses" was pointing to ibotta_uplift_multiple_response_example.ipynb, but if I am not mistaken, it should be pointing to mr_uplift_one_response_example.ipynb