### PR TITLE
Fix Logic Error for Predicting Erupt Curves With New Data

### DIFF
--- a/mr_uplift/mr_uplift.py
+++ b/mr_uplift/mr_uplift.py
@@ -229,7 +229,8 @@ class MRUplift(object):
             objective_weights[:, 0] = np.linspace(0.0, 1.0, num=11)
             objective_weights[:, 1] = -np.linspace(1.0, 0.0, num=11)
 
-        if x or y or t is None:
+        if any([q is None for q in [x, y, t] ]):
+            print("Using Test Data Set")
             x_train, x, y_train, y, t_train, t = train_test_split(
                 self.x, self.y, self.t, test_size=self.test_size,
                 random_state=self.random_state)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def parse_description(description):
         ])
 
 DISTNAME = "mr_uplift"
-VERSION = "0.0.2"
+VERSION = "0.0.3"
 DESCRIPTION = "Machine learning tools for uplift models"
 with open("README.rst") as f:
     LONG_DESCRIPTION = parse_description(f.read())

--- a/tests/test_ibotta_uplift.py
+++ b/tests/test_ibotta_uplift.py
@@ -57,3 +57,5 @@ class TestMRUplift(object):
             y.shape[1])
 
         assert uplift_model.get_erupt_curves()
+        
+        assert uplift_model.get_erupt_curves(x = x, y = y, t = t)


### PR DESCRIPTION
The Current functionality for `get_erupt_curves` will check to see if any of input data is missing. However this if statement was logically incorrect. The update fixes that issue.