### PR TITLE
Update permutation varimp

### DIFF
--- a/mr_uplift/erupt.py
+++ b/mr_uplift/erupt.py
@@ -140,8 +140,8 @@ def get_erupts_curves_aupc(y, tmt, ice, unique_tmts, objective_weights,
         erupts_random['assignment'] = 'random'
         erupts['assignment'] = 'model'
 
-        erupts['treatment'] = -1
-
+        erupts['treatment'] = '-1'
+        erupts_random['treatment'] = '-1'
 
         erupts = pd.concat([erupts, erupts_random], axis=0)
 
@@ -164,7 +164,7 @@ def get_erupts_curves_aupc(y, tmt, ice, unique_tmts, objective_weights,
         erupts = erupt(y, tmt, t_rep, weights=observation_weights,
                        names=names)
 
-        erupts['weights'] = -1
+        erupts['weights'] = '-1'
         erupts['treatment'] = t
         erupts['assignment'] = 'ate'
 

--- a/mr_uplift/erupt.py
+++ b/mr_uplift/erupt.py
@@ -140,6 +140,9 @@ def get_erupts_curves_aupc(y, tmt, ice, unique_tmts, objective_weights,
         erupts_random['assignment'] = 'random'
         erupts['assignment'] = 'model'
 
+        erupts['treatment'] = -1
+
+
         erupts = pd.concat([erupts, erupts_random], axis=0)
 
         dists = pd.DataFrame(optim_tmt).iloc[:, 0].value_counts()
@@ -152,6 +155,23 @@ def get_erupts_curves_aupc(y, tmt, ice, unique_tmts, objective_weights,
 
         all_erupts.append(erupts)
         all_distributions.append(dist_treatments)
+
+    for t in unique_tmts:
+
+        t_rep = np.repeat(t, y.shape[0])
+        str_obj_weight = str(t)
+
+        print(observation_weights.shape)
+
+        erupts = erupt(y, tmt, t_rep, weights=observation_weights,
+                       names=names)
+
+        erupts['weights'] = -1
+        erupts['treatment'] = t
+
+        erupts['assignment'] = 'ate'
+
+        all_erupts.append(erupts)
 
     all_erupts = pd.concat(all_erupts)
     all_distributions = pd.concat(all_distributions)

--- a/mr_uplift/erupt.py
+++ b/mr_uplift/erupt.py
@@ -161,14 +161,11 @@ def get_erupts_curves_aupc(y, tmt, ice, unique_tmts, objective_weights,
         t_rep = np.repeat(t, y.shape[0])
         str_obj_weight = str(t)
 
-        print(observation_weights.shape)
-
         erupts = erupt(y, tmt, t_rep, weights=observation_weights,
                        names=names)
 
         erupts['weights'] = -1
         erupts['treatment'] = t
-
         erupts['assignment'] = 'ate'
 
         all_erupts.append(erupts)

--- a/mr_uplift/mr_uplift.py
+++ b/mr_uplift/mr_uplift.py
@@ -442,6 +442,8 @@ class MRUplift(object):
                 self.x, self.y, self.t, test_size=self.test_size,
                 random_state=self.random_state)
 
+        #subset number of observations
+        x = x[:num_sample]
 
         original_decisions = self.predict_optimal_treatments(x,
         objective_weights=objective_weights, treatments=treatments,
@@ -452,7 +454,7 @@ class MRUplift(object):
             shuffled_index = np.arange(x.shape[0])
             np.random.shuffle(shuffled_index)
 
-            shuffled_index = shuffled_index[:num_sample]
+            shuffled_index = shuffled_index
 
             x_copy = x.copy()
             x_copy[:,p] = x_copy[:,p][shuffled_index]

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def parse_description(description):
         ])
 
 DISTNAME = "mr_uplift"
-VERSION = "0.0.10"
+VERSION = "0.0.11"
 DESCRIPTION = "Machine learning tools for uplift models"
 with open("README.rst") as f:
     LONG_DESCRIPTION = parse_description(f.read())

--- a/tests/test_mr_uplift.py
+++ b/tests/test_mr_uplift.py
@@ -122,3 +122,16 @@ class TestMRUplift(object):
         oos_re = uplift_model.get_random_erupts()
 
         assert oos_re['mean'].iloc[0] > 0
+
+    def test_varimp(self):
+        num_obs = 10000
+        param_grid = dict(num_nodes=[8], dropout=[.1], activation=['relu'], num_layers=[2], epochs=[30], batch_size=[100])
+
+        y, x, t = get_simple_uplift_data(num_obs)
+
+        uplift_model = MRUplift()
+        uplift_model.fit(x, y, t.reshape(-1, 1),
+                         n_jobs=1, param_grid = param_grid)
+        varimp = uplift_model.permutation_varimp(objective_weights = np.array([.7,-.3,0]).reshape(1,-1))
+
+        assert varimp['permutation_varimp_metric'].iloc[0]>varimp['permutation_varimp_metric'].iloc[1]


### PR DESCRIPTION
- Updating permutation variable importance. Including tests as well.
- Updating erupt curves so it will calculate ATE for treatments. 