### PR TITLE
Ensure treatment erupt loop is within the objective weights scope

### DIFF
--- a/mr_uplift/erupt.py
+++ b/mr_uplift/erupt.py
@@ -195,19 +195,19 @@ def get_erupts_curves_aupc(y, tmt, ice, unique_tmts, objective_weights,
         all_erupts.append(erupts)
         all_distributions.append(dist_treatments)
 
-    for t in unique_tmts:
+        for t in unique_tmts:
 
-        t_rep = np.repeat(t, y.shape[0]).reshape(-1,1)
-        str_obj_weight = str(t)
+            t_rep = np.repeat(t, y.shape[0]).reshape(-1,1)
+            str_obj_weight = str(t)
 
-        erupts = erupt(y_temp, tmt.reshape(-1,1), t_rep, weights=observation_weights,
-                       names=names)
+            erupts = erupt(y_temp, tmt.reshape(-1,1), t_rep, weights=observation_weights,
+                           names=names)
 
-        erupts['weights'] = '-1'
-        erupts['treatment'] = str_obj_weight
-        erupts['assignment'] = 'ate'
+            erupts['weights'] = '-1'
+            erupts['treatment'] = str_obj_weight
+            erupts['assignment'] = 'ate'
 
-        all_erupts.append(erupts)
+            all_erupts.append(erupts)
 
     all_erupts = pd.concat(all_erupts)
     all_distributions = pd.concat(all_distributions)


### PR DESCRIPTION
## Pull Request Template
<!--- Provide a general summary of your changes in the Title above -->
<!--- If applicable, link to related GitHub Issue  -->

### Description
<!--- Describe your changes in detail -->
Average treatment erupt curve calculation was outside of the objective weights scope, therefore only the erupt for treatments with the last set of objective weights were calculated.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ensure treatment erupt curves are calculated correctly.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->
Not tested
### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added reviewers to the PR.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
